### PR TITLE
GJ-2506 fix variable update mechanism in operators

### DIFF
--- a/src/main/scala/com/getjenny/analyzer/atoms/DefaultFactoryAtomic.scala
+++ b/src/main/scala/com/getjenny/analyzer/atoms/DefaultFactoryAtomic.scala
@@ -12,6 +12,7 @@ class DefaultFactoryAtomic extends AtomicFactoryTrait[List[String], AbstractAtom
     "similar",
     "synonym",
     "regex",
+    "lastTravStateIs",
     "matchPatternRegex",
     "matchDateDDMMYYYY",
     "existsVariable",
@@ -34,6 +35,7 @@ class DefaultFactoryAtomic extends AtomicFactoryTrait[List[String], AbstractAtom
   AbstractAtomic = name.filter(c => !c.isWhitespace ) match {
     case "keyword" => new KeywordAtomic(argument, restrictedArgs)
     case "regex" => new RegularExpressionAtomic(argument, restrictedArgs)
+    case "lastTravStateIs" => new LastTravStateIsAtomic(argument, restrictedArgs)
     case "matchPatternRegex" => new MatchPatternRegexAtomic(argument, restrictedArgs)
     case "matchDateDDMMYYYY" => new MatchDateDDMMYYYYAtomic(argument, restrictedArgs)
     case "existsVariable" => new ExistsVariableAtomic(argument, restrictedArgs)

--- a/src/main/scala/com/getjenny/analyzer/operators/BooleanNotOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/BooleanNotOperator.scala
@@ -1,8 +1,7 @@
 package com.getjenny.analyzer.operators
 
 import com.getjenny.analyzer.expressions._
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
 
 /** Not Operator
   *
@@ -36,11 +35,11 @@ class BooleanNotOperator(child: List[Expression]) extends AbstractOperator(child
     }
   }
 
-  def evaluate(query: String, data: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
+  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
     val res = child.headOption match {
-      case Some(arg) => arg.matches(query, data)
+      case Some(arg) => arg.matches(query, analyzersDataInternal)
       case _ => throw OperatorException("BooleanNotOperator: inner expression is empty")
     }
-    Result(score=1 - res.score, data = res.data)
+    Result(score = 1 - res.score, data = analyzersDataInternal)
   }
 }

--- a/src/main/scala/com/getjenny/analyzer/operators/BooleanNotOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/BooleanNotOperator.scala
@@ -35,11 +35,11 @@ class BooleanNotOperator(child: List[Expression]) extends AbstractOperator(child
     }
   }
 
-  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
+  def evaluate(query: String, data: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
     val res = child.headOption match {
-      case Some(arg) => arg.matches(query, analyzersDataInternal)
+      case Some(arg) => arg.matches(query, data)
       case _ => throw OperatorException("BooleanNotOperator: inner expression is empty")
     }
-    Result(score = 1 - res.score, data = analyzersDataInternal)
+    Result(score = 1 - res.score, data = data)
   }
 }

--- a/src/main/scala/com/getjenny/analyzer/operators/BooleanOrOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/BooleanOrOperator.scala
@@ -25,17 +25,44 @@ class BooleanOrOperator(children: List[Expression]) extends AbstractOperator(chi
     }
   }
 
-  def evaluate(query: String, data: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
-    def loop(l: List[Expression]): Result = {
-      val res = l.headOption match {
-        case Some(arg) => arg.matches(query, data)
-        case _ => throw OperatorException("BooleanOrOperator: inner expression is empty")
+  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
+    def booleanOr(l: List[Expression]): Result = {
+      val res = l(0).matches(query, analyzersDataInternal)
+      if (l.tail.isEmpty) {
+        Result(score = 1.0d - res.score,
+          AnalyzersDataInternal(
+            context = analyzersDataInternal.context,
+            traversedStates = analyzersDataInternal.traversedStates,
+            // map summation order is important, as res elements must override pre-existing elements
+            extractedVariables = analyzersDataInternal.extractedVariables ++ res.data.extractedVariables,
+            data = analyzersDataInternal.data ++ res.data.data
+          )
+        )
+      } else {
+        val resTail = booleanOr(l.tail)
+        Result(score = (1.0d - res.score) * resTail.score,
+          AnalyzersDataInternal(
+            context = analyzersDataInternal.context,
+            traversedStates = analyzersDataInternal.traversedStates,
+            // map summation order is important, as res elements must override resTail existing elements
+            extractedVariables = resTail.data.extractedVariables ++ res.data.extractedVariables,
+            data = resTail.data.data ++ res.data.data
+          )
+        )
       }
-      if (res.score === 1) Result(score=1, data = res.data)
-      else if (l.tail.isEmpty) Result(score=0, data = res.data)
-      else loop(l.tail)
     }
-    loop(children)
+    val resBooleanOr = booleanOr(children)
+    val finalScore = 1.0d - resBooleanOr.score
+    if (finalScore < 1.0d) {
+      Result(
+        score = finalScore,
+        data = analyzersDataInternal
+      )
+    } else {
+      Result(
+        score = finalScore,
+        data = resBooleanOr.data
+      )
+    }
   }
 }
-

--- a/src/main/scala/com/getjenny/analyzer/operators/ConjunctionOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/ConjunctionOperator.scala
@@ -1,8 +1,7 @@
 package com.getjenny.analyzer.operators
 
 import com.getjenny.analyzer.expressions._
-import com.getjenny.analyzer.analyzers._
-import scalaz.Scalaz._
+import scala.math.Ordering.Double.equiv
 
 /**
   * Created by mal on 21/02/2017.
@@ -11,44 +10,60 @@ import scalaz.Scalaz._
 class ConjunctionOperator(children: List[Expression]) extends AbstractOperator(children: List[Expression]) {
   override def toString: String = "ConjunctionOperator(" + children.mkString(", ") + ")"
   def add(e: Expression, level: Int = 0): AbstractOperator = {
-    if (level === 0) {
-      new ConjunctionOperator(e :: children)
-    } else if(children.isEmpty){
-      throw OperatorException("ConjunctionOperator: children list is empty")
-    } else {
-      children.headOption match {
-        case Some(t) =>
-          t match {
-            case c: AbstractOperator => new ConjunctionOperator(c.add(e, level - 1) :: children.tail)
-            case _ => throw OperatorException("ConjunctionOperator: trying to add to smt else than an operator")
+    level match {
+      case 0 => new ConjunctionOperator(e :: children)
+      case _ =>
+        if (children.isEmpty) {
+          throw OperatorException("ConjunctionOperator: children list is empty")
+        } else {
+          children.headOption match {
+            case Some(t) =>
+              t match {
+                case c: AbstractOperator => new ConjunctionOperator(c.add(e, level - 1) :: children.tail)
+                case _ => throw OperatorException("ConjunctionOperator: trying to add to smt else than an operator")
+              }
+            case _ => throw OperatorException("ConjunctionOperator: trying to add None instead of an operator")
           }
-        case _ => throw OperatorException("ConjunctionOperator: trying to add None instead of an operator")
-
-      }
+        }
     }
   }
 
-  def evaluate(query: String, data: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
+  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = AnalyzersDataInternal()): Result = {
     def conjunction(l: List[Expression]): Result = {
-      val eval = l.headOption match {
-        case Some(t) =>
-          t.evaluate(query, data)
-        case _ =>
-          throw OperatorException("ConjunctionOperator: argument list is empty")
-      }
-      if (eval.score === 0) Result(score = 0, data = eval.data)
-      else if (l.tail.isEmpty) eval
-      else {
-        val res = conjunction(l.tail)
-
-        Result(score = eval.score * res.score,
+      val valHead = l(0).evaluate(query, analyzersDataInternal)
+      if (l.tail.isEmpty) {
+        Result(score = valHead.score,
           AnalyzersDataInternal(
-            context = data.context,
-            traversedStates = data.traversedStates,
-            extractedVariables = eval.data.extractedVariables ++ res.data.extractedVariables,
-            data = eval.data.data ++ res.data.data
+            context = analyzersDataInternal.context,
+            traversedStates = analyzersDataInternal.traversedStates,
+            // map summation order is important, as valHead elements must override pre-existing elements
+            extractedVariables = analyzersDataInternal.extractedVariables ++ valHead.data.extractedVariables,
+            data = analyzersDataInternal.data ++ valHead.data.data
           )
         )
+      } else {
+        val valTail = conjunction(l.tail)
+        val finalScore = valHead.score * valTail.score
+        if (equiv(finalScore, 0.0d)) {
+          Result(score = finalScore,
+            AnalyzersDataInternal(
+              context = analyzersDataInternal.context,
+              traversedStates = analyzersDataInternal.traversedStates,
+              extractedVariables = analyzersDataInternal.extractedVariables,
+              data = analyzersDataInternal.data
+            )
+          )
+        } else {
+          Result(score = finalScore,
+            AnalyzersDataInternal(
+              context = analyzersDataInternal.context,
+              traversedStates = analyzersDataInternal.traversedStates,
+              // map summation order is important, as valHead elements must override valTail existing elements
+              extractedVariables = valTail.data.extractedVariables ++ valHead.data.extractedVariables,
+              data = valTail.data.data ++ valHead.data.data
+            )
+          )
+        }
       }
     }
     conjunction(children)

--- a/src/main/scala/com/getjenny/analyzer/operators/DisjunctionOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/DisjunctionOperator.scala
@@ -1,8 +1,8 @@
 package com.getjenny.analyzer.operators
 
 import com.getjenny.analyzer.expressions._
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
+import scala.math.Ordering.Double.equiv
 
 /**
   * Created by mal on 21/02/2017.
@@ -25,37 +25,43 @@ class DisjunctionOperator(children: List[Expression]) extends AbstractOperator(c
     }
   }
 
-  def evaluate(query: String, data: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
+  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
     def compDisjunction(l: List[Expression]): Result = {
-      val res = l.headOption match {
-        case Some(t) => {
-          t.evaluate(query, data)
-        }
-        case _ =>
-          throw OperatorException("DisjunctionOperator: operator argument is empty")
-      }
-
-      l.tailOption match {
-        case Some(t) =>
-          if (t.nonEmpty) {
-            val compDisj = compDisjunction(t)
-            Result(score = (1.0 - res.score) * compDisj.score,
-              AnalyzersDataInternal(
-                context = data.context,
-                traversedStates = data.traversedStates,
-                extractedVariables = compDisj.data.extractedVariables ++ res.data.extractedVariables,
-                data = compDisj.data.data ++ res.data.data
-              )
-            )
-          } else {
-            Result(score = 1.0 - res.score, data = res.data)
-          }
-        case _ =>
-          throw OperatorException("DisjunctionOperator: the tail must be a list")
+      val res = l(0).evaluate(query, analyzersDataInternal)
+      if (l.tail.isEmpty) {
+        Result(score = 1.0d - res.score,
+          AnalyzersDataInternal(
+            context = analyzersDataInternal.context,
+            traversedStates = analyzersDataInternal.traversedStates,
+            extractedVariables = analyzersDataInternal.extractedVariables ++ res.data.extractedVariables,
+            data = analyzersDataInternal.data ++ res.data.data
+          )
+        )
+      } else {
+        val resTail = compDisjunction(l.tail)
+        Result(score = (1.0d - res.score) * resTail.score,
+          AnalyzersDataInternal(
+            context = analyzersDataInternal.context,
+            traversedStates = analyzersDataInternal.traversedStates,
+            // map summation order is important, as res elements must override resTail existing elements
+            extractedVariables = resTail.data.extractedVariables ++ res.data.extractedVariables,
+            data = resTail.data.data ++ res.data.data
+          )
+        )
       }
     }
-    val comp_disj = compDisjunction(children)
-    Result(score=1.0 - comp_disj.score, data = comp_disj.data)
+    val resCompDisj = compDisjunction(children)
+    val finalScore = 1.0d - resCompDisj.score
+    if (equiv(finalScore, 0.0d)) {
+      Result(
+        score = finalScore,
+        data = analyzersDataInternal
+      )
+    } else {
+      Result(
+        score = finalScore,
+        data = resCompDisj.data
+      )
+    }
   }
 }
-

--- a/src/main/scala/com/getjenny/analyzer/operators/MaxOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/MaxOperator.scala
@@ -31,18 +31,30 @@ class MaxOperator(children: List[Expression]) extends AbstractOperator(children:
         case Some(arg) => arg.evaluate(query, data)
         case _ => throw OperatorException("MaxOperator: inner expression is empty")
       }
-      if (l.tail.isEmpty) {
-        Result(score = val1.score,
-          AnalyzersDataInternal(
-            context = data.context,
-            traversedStates = data.traversedStates,
-            extractedVariables = val1.data.extractedVariables,
-            data = val1.data.data
-          )
+      val resultHead = Result(
+        score = val1.score,
+        AnalyzersDataInternal(
+          context = data.context,
+          traversedStates = data.traversedStates,
+          extractedVariables = data.extractedVariables ++ val1.data.extractedVariables,
+          data = data.data ++ val1.data.data
         )
+      )
+      if (l.tail.isEmpty) {
+        resultHead
       } else {
         val val2 = compMax(l.tail)
-        if(val1.score >= val2.score) val1 else val2
+        if (val1.score === val2.score)
+          Result(
+            score = val1.score,
+            AnalyzersDataInternal(
+              context = data.context,
+              traversedStates = data.traversedStates,
+              extractedVariables = val2.data.extractedVariables ++ val1.data.extractedVariables,
+              data = val2.data.data ++ val1.data.data
+            )
+          )
+        else if(val1.score >= val2.score) resultHead else val2
       }
     }
     compMax(children)

--- a/src/main/scala/com/getjenny/analyzer/operators/MaxOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/MaxOperator.scala
@@ -27,7 +27,10 @@ class MaxOperator(children: List[Expression]) extends AbstractOperator(children:
 
   def evaluate(query: String, data: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
     def compMax(l: List[Expression]): Result = {
-      val val1 = l.head.evaluate(query, data)
+      val val1 = l.headOption match {
+        case Some(arg) => arg.evaluate(query, data)
+        case _ => throw OperatorException("MaxOperator: inner expression is empty")
+      }
       if (l.tail.isEmpty) {
         Result(score = val1.score,
           AnalyzersDataInternal(

--- a/src/main/scala/com/getjenny/analyzer/operators/ReinfConjunctionOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/ReinfConjunctionOperator.scala
@@ -1,7 +1,7 @@
 package com.getjenny.analyzer.operators
 
 import com.getjenny.analyzer.expressions._
-import scalaz.Scalaz._
+import scala.math.Ordering.Double.equiv
 
 /**
   * Created by angelo on 18/01/2018.
@@ -10,48 +10,62 @@ import scalaz.Scalaz._
 class ReinfConjunctionOperator(children: List[Expression]) extends AbstractOperator(children: List[Expression]) {
   override def toString: String = "ReinfConjunctionOperator(" + children.mkString(", ") + ")"
   def add(e: Expression, level: Int = 0): AbstractOperator = {
-    if (level === 0) {
-      new ReinfConjunctionOperator(e :: children)
-    } else if(children.isEmpty){
-      throw OperatorException("ReinfConjunctionOperator children list is empty")
-    } else {
-      children.headOption match {
-        case Some(t) =>
-          t match {
-            case c: AbstractOperator => new ReinfConjunctionOperator(c.add(e, level - 1) :: children.tail)
-            case _ => throw OperatorException("ReinfConjunctionOperator: trying to add to smt else than an operator")
+
+    level match {
+      case 0 => new ReinfConjunctionOperator(e :: children)
+      case _ =>
+        if (children.isEmpty) {
+          throw OperatorException("ReinfConjunctionOperator children list is empty")
+        } else {
+          children.headOption match {
+            case Some(t) =>
+              t match {
+                case c: AbstractOperator => new ReinfConjunctionOperator(c.add(e, level - 1) :: children.tail)
+                case _ => throw OperatorException("ReinfConjunctionOperator: trying to add to smt else than an operator")
+              }
+            case _ =>
+              throw OperatorException("ReinfConjunctionOperator: trying to add None instead of an operator")
           }
-        case _ =>
-          throw OperatorException("ReinfConjunctionOperator: trying to add None instead of an operator")
-      }
+        }
     }
   }
 
-  def evaluate(query: String, data: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
+  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
     def reinfConjunction(l: List[Expression]): Result = {
-      val res = l.head.evaluate(query, data)
+      val valHead = l(0).evaluate(query, analyzersDataInternal)
       if (l.tail.isEmpty) {
-//        println("SCORE_NIL: " + res.score * 1.1 + "(" + res.score + ")")
-        Result(score = res.score * 1.1,
+        Result(score = valHead.score * 1.1,
           AnalyzersDataInternal(
-            context = data.context,
-            traversedStates = data.traversedStates,
-            extractedVariables = data.extractedVariables ++ res.data.extractedVariables,
-            data = res.data.data
+            context = analyzersDataInternal.context,
+            traversedStates = analyzersDataInternal.traversedStates,
+            // map summation order is important, as valHead elements must override pre-existing elements
+            extractedVariables = analyzersDataInternal.extractedVariables ++ valHead.data.extractedVariables,
+            data = analyzersDataInternal.data ++ valHead.data.data
           )
         )
       } else {
-        val val1 = l.head.evaluate(query, data)
-        val val2 = reinfConjunction(l.tail)
-//        println("SCORE_NOT_NIL: " + (val1.score * 1.1) * val2.score + "(" + val1.score + ")" + "(" + val2.score + ")")
-        Result(score = (val1.score * 1.1) * val2.score,
-          AnalyzersDataInternal(
-            context = data.context,
-            traversedStates = data.traversedStates,
-            extractedVariables = val1.data.extractedVariables ++ val2.data.extractedVariables,
-            data = data.data ++ val1.data.data ++ val2.data.data
+        val valTail = reinfConjunction(l.tail)
+        val finalScore = (valHead.score * 1.1) * valTail.score
+        if (equiv(finalScore, 0)) {
+          Result(score = finalScore,
+            AnalyzersDataInternal(
+              context = analyzersDataInternal.context,
+              traversedStates = analyzersDataInternal.traversedStates,
+              extractedVariables = analyzersDataInternal.extractedVariables,
+              data = analyzersDataInternal.data
+            )
           )
-        )
+        } else {
+          Result(score = finalScore,
+            AnalyzersDataInternal(
+              context = analyzersDataInternal.context,
+              traversedStates = analyzersDataInternal.traversedStates,
+              // map summation order is important, as valHead elements must override valTail existing elements
+              extractedVariables = valTail.data.extractedVariables ++ valHead.data.extractedVariables,
+              data = valTail.data.data ++ valHead.data.data
+            )
+          )
+        }
       }
     }
     reinfConjunction(children)

--- a/src/main/scala/com/getjenny/analyzer/operators/ReinfConjunctionOperator.scala
+++ b/src/main/scala/com/getjenny/analyzer/operators/ReinfConjunctionOperator.scala
@@ -30,17 +30,20 @@ class ReinfConjunctionOperator(children: List[Expression]) extends AbstractOpera
     }
   }
 
-  def evaluate(query: String, analyzersDataInternal: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
+  def evaluate(query: String, data: AnalyzersDataInternal = new AnalyzersDataInternal): Result = {
     def reinfConjunction(l: List[Expression]): Result = {
-      val valHead = l(0).evaluate(query, analyzersDataInternal)
+      val valHead = l.headOption match {
+        case Some(arg) => arg.evaluate(query, data)
+        case _ => throw OperatorException("ReinfConjunctionOperator: inner expression is empty")
+      }
       if (l.tail.isEmpty) {
         Result(score = valHead.score * 1.1,
           AnalyzersDataInternal(
-            context = analyzersDataInternal.context,
-            traversedStates = analyzersDataInternal.traversedStates,
+            context = data.context,
+            traversedStates = data.traversedStates,
             // map summation order is important, as valHead elements must override pre-existing elements
-            extractedVariables = analyzersDataInternal.extractedVariables ++ valHead.data.extractedVariables,
-            data = analyzersDataInternal.data ++ valHead.data.data
+            extractedVariables = data.extractedVariables ++ valHead.data.extractedVariables,
+            data = data.data ++ valHead.data.data
           )
         )
       } else {
@@ -49,17 +52,17 @@ class ReinfConjunctionOperator(children: List[Expression]) extends AbstractOpera
         if (equiv(finalScore, 0)) {
           Result(score = finalScore,
             AnalyzersDataInternal(
-              context = analyzersDataInternal.context,
-              traversedStates = analyzersDataInternal.traversedStates,
-              extractedVariables = analyzersDataInternal.extractedVariables,
-              data = analyzersDataInternal.data
+              context = data.context,
+              traversedStates = data.traversedStates,
+              extractedVariables = data.extractedVariables,
+              data = data.data
             )
           )
         } else {
           Result(score = finalScore,
             AnalyzersDataInternal(
-              context = analyzersDataInternal.context,
-              traversedStates = analyzersDataInternal.traversedStates,
+              context = data.context,
+              traversedStates = data.traversedStates,
               // map summation order is important, as valHead elements must override valTail existing elements
               extractedVariables = valTail.data.extractedVariables ++ valHead.data.extractedVariables,
               data = valTail.data.data ++ valHead.data.data

--- a/src/test/scala/com/getjenny/analyzer/analyzers/CheckTimestampAtomicTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/CheckTimestampAtomicTest.scala
@@ -7,6 +7,7 @@ package com.getjenny.analyzer.analyzers
 import com.getjenny.analyzer.expressions.AnalyzersDataInternal
 import com.getjenny.analyzer.util.Time
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 
 class CheckTimestampAtomicTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/com/getjenny/analyzer/analyzers/ComplexAnalyzersExpressionsTests.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/ComplexAnalyzersExpressionsTests.scala
@@ -6,6 +6,7 @@ package com.getjenny.analyzer.analyzers
 
 import com.getjenny.analyzer.expressions.AnalyzersDataInternal
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 
 class ComplexAnalyzersExpressionsTests extends FlatSpec with Matchers {
 

--- a/src/test/scala/com/getjenny/analyzer/analyzers/DoubleNumberVariableAtomicTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/DoubleNumberVariableAtomicTest.scala
@@ -4,9 +4,10 @@ package com.getjenny.analyzer.analyzers
   * Created by Angelo Leto <angelo@getjenny.com> on 03/03/17.
   */
 
+import com.getjenny.analyzer.atoms.ExceptionAtomic
 import com.getjenny.analyzer.expressions.AnalyzersDataInternal
 import org.scalatest._
-import com.getjenny.analyzer.atoms.ExceptionAtomic
+import org.scalatest.matchers.should.Matchers
 
 class DoubleNumberVariableAtomicTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/com/getjenny/analyzer/analyzers/GenericAnalyzersTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/GenericAnalyzersTest.scala
@@ -4,8 +4,8 @@ package com.getjenny.analyzer.analyzers
   * Created by Angelo Leto <angelo@getjenny.com> on 03/03/17.
   */
 
-
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 
 class GenericAnalyzersTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/com/getjenny/analyzer/analyzers/MultiStateOpeningTimeTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/MultiStateOpeningTimeTest.scala
@@ -6,7 +6,7 @@ package com.getjenny.analyzer.analyzers
 
 import com.getjenny.analyzer.expressions.AnalyzersDataInternal
 import org.scalatest._
-import com.getjenny.analyzer.atoms.ExceptionAtomic
+import org.scalatest.matchers.should.Matchers
 
 class MultiStateOpeningTimeTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/com/getjenny/analyzer/analyzers/NumericalComparisonAtomicTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/NumericalComparisonAtomicTest.scala
@@ -6,6 +6,7 @@ package com.getjenny.analyzer.analyzers
 
 import com.getjenny.analyzer.expressions.AnalyzersDataInternal
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 
 class NumericalComparisonAtomicTest extends FlatSpec with Matchers {
 

--- a/src/test/scala/com/getjenny/analyzer/analyzers/OperatorOrderTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/OperatorOrderTest.scala
@@ -1,0 +1,369 @@
+package com.getjenny.analyzer.analyzers
+
+/**
+  * Created by Michele Boggia <michele.boggia@getjenny.com> on 30/07/20.
+  */
+
+import com.getjenny.analyzer.expressions.AnalyzersDataInternal
+import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+
+class OperatorOrderTest extends FlatSpec with Matchers {
+
+  val restrictedArgs: Map[String, String] = Map.empty[String, String]
+  val travStateId: String = "00dac6ee-80a1-4054-baac-747a80bb7738"
+  val emailExtracted: String = "test1@example.com"
+  val emailInQuery: String = "test2@example.com"
+  val queryWithEmail: String = "my email is " + emailInQuery
+  val queryNoEmail: String = "this query does not contain any email address!"
+  val extractedVarKey = "aaa"
+  val extractedVarValue = "bbb"
+  val extractedEmailKey = "email_address.0"
+  val extractedQueryKey = "customer_message.0"
+  val data: AnalyzersDataInternal = AnalyzersDataInternal(
+    traversedStates = Vector[String](travStateId),
+    extractedVariables = Map[String, String](extractedVarKey -> extractedVarValue, extractedEmailKey -> emailExtracted)
+  )
+  val atomExtractEmail: String = """matchPatternRegex("[email_address](?:([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+))")"""
+  val atomExtractQuery: String = """matchPatternRegex("[customer_message](.*)")"""
+  val atomLastTravStateTrue: String = """lastTravStateIs("""" + travStateId + """")"""
+  val atomLastTravStateFalse: String = """lastTravStateIs("1234")"""
+  def analyzerString(operator: String, operands: List[String]): String = operator + "(" + operands.mkString(",") + ")"
+  val scoreSuccess: Double = 1.0d
+  val scoreFailure: Double = 0.0d
+  val scoreSuccessReinf1: Double = 1.1d
+  val scoreSuccessReinf2: Double = scoreSuccessReinf1 * scoreSuccessReinf1
+  val scoreSuccessReinf3: Double = scoreSuccessReinf2 * scoreSuccessReinf1
+
+  val operatorBooleanAnd: String = "booleanAnd"
+  val operatorBooleanOr: String = "booleanOr"
+  val operatorBooleanNot: String = "booleanNot"
+  val operatorConjunction: String = "conjunction"
+  val operatorDisjunction: String = "disjunction"
+  val operatorReinfConjunction: String = "reinfConjunction"
+
+  operatorBooleanAnd should
+  "trigger and extract email address when matching regex pattern" in {
+      val analyzer = new DefaultAnalyzer(
+        analyzerString(operatorBooleanAnd, List(atomExtractEmail)),
+        restrictedArgs
+      )
+      val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+      analyzerValue.score shouldBe scoreSuccess
+      analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+      analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+      analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    }
+  it should "trigger and extract email address when matching regex pattern and lastTravStateIs is true" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanAnd,List(atomExtractEmail, atomLastTravStateTrue)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when lastTravStateIs is true and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanAnd,List(atomLastTravStateTrue, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and not update email address when matching regex pattern and lastTravStateIs is false" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanAnd,List(atomExtractEmail, atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and not update email address when lastTravStateIs is false and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanAnd,List(atomLastTravStateFalse, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract both email address and customer message" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanAnd,List(atomLastTravStateTrue, atomExtractEmail, atomExtractQuery)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+
+  operatorBooleanOr should
+    "trigger and extract email address when matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanOr, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when matching regex pattern and lastTravStateIs is false" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanOr,List(atomExtractEmail, atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when lastTravStateIs is false and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanOr,List(atomLastTravStateFalse, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract both email address and customer message" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanOr,List(atomLastTravStateFalse, atomExtractEmail, atomExtractQuery)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+
+  operatorBooleanNot should
+    "trigger and return previously extracted email when not matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanNot, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryNoEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and return previously extracted email when matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorBooleanNot, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+
+  operatorConjunction should
+    "trigger and extract email address when matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorConjunction, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when matching regex pattern and lastTravStateIs is true" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorConjunction,List(atomExtractEmail, atomLastTravStateTrue)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when lastTravStateIs is true and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorConjunction,List(atomLastTravStateTrue, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and not update email address when matching regex pattern and lastTravStateIs is false" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorConjunction,List(atomExtractEmail, atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and not update email address when lastTravStateIs is false and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorConjunction,List(atomLastTravStateFalse, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract both email address and customer message" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorConjunction,List(atomLastTravStateTrue, atomExtractEmail, atomExtractQuery)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+
+  operatorDisjunction should
+    "trigger and extract email address when matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorDisjunction, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when matching regex pattern and lastTravStateIs is false" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorDisjunction,List(atomExtractEmail, atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when lastTravStateIs is false and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorDisjunction,List(atomLastTravStateFalse, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract both email address and customer message" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorDisjunction,List(atomLastTravStateFalse, atomExtractEmail, atomExtractQuery)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+
+  operatorReinfConjunction should
+    "trigger and extract email address when matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorReinfConjunction, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccessReinf1
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when matching regex pattern and lastTravStateIs is true" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorReinfConjunction,List(atomExtractEmail, atomLastTravStateTrue)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccessReinf2
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract email address when lastTravStateIs is true and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorReinfConjunction,List(atomLastTravStateTrue, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccessReinf2
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and not update email address when matching regex pattern and lastTravStateIs is false" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorReinfConjunction,List(atomExtractEmail, atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "not trigger and not update email address when lastTravStateIs is false and matching regex pattern" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorReinfConjunction,List(atomLastTravStateFalse, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+  it should "trigger and extract both email address and customer message" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorReinfConjunction,List(atomLastTravStateTrue, atomExtractEmail, atomExtractQuery)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccessReinf3
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+  }
+}

--- a/src/test/scala/com/getjenny/analyzer/analyzers/OperatorOrderTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/analyzers/OperatorOrderTest.scala
@@ -41,6 +41,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
   val operatorConjunction: String = "conjunction"
   val operatorDisjunction: String = "disjunction"
   val operatorReinfConjunction: String = "reinfConjunction"
+  val operatorMax: String = "max"
 
   operatorBooleanAnd should
   "trigger and extract email address when matching regex pattern" in {
@@ -53,6 +54,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
       analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
       analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
       analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
     }
   it should "trigger and extract email address when matching regex pattern and lastTravStateIs is true" in {
     val analyzer = new DefaultAnalyzer(
@@ -64,6 +66,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when lastTravStateIs is true and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -75,6 +78,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and not update email address when matching regex pattern and lastTravStateIs is false" in {
     val analyzer = new DefaultAnalyzer(
@@ -86,6 +90,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and not update email address when lastTravStateIs is false and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -97,6 +102,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract both email address and customer message" in {
     val analyzer = new DefaultAnalyzer(
@@ -109,6 +115,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
 
   operatorBooleanOr should
@@ -122,6 +129,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when matching regex pattern and lastTravStateIs is false" in {
     val analyzer = new DefaultAnalyzer(
@@ -133,6 +141,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when lastTravStateIs is false and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -144,6 +153,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract both email address and customer message" in {
     val analyzer = new DefaultAnalyzer(
@@ -156,6 +166,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
 
   operatorBooleanNot should
@@ -169,6 +180,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and return previously extracted email when matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -180,6 +192,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
 
   operatorConjunction should
@@ -193,6 +206,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when matching regex pattern and lastTravStateIs is true" in {
     val analyzer = new DefaultAnalyzer(
@@ -204,6 +218,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when lastTravStateIs is true and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -215,6 +230,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and not update email address when matching regex pattern and lastTravStateIs is false" in {
     val analyzer = new DefaultAnalyzer(
@@ -226,6 +242,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and not update email address when lastTravStateIs is false and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -237,6 +254,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract both email address and customer message" in {
     val analyzer = new DefaultAnalyzer(
@@ -249,6 +267,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
 
   operatorDisjunction should
@@ -262,6 +281,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when matching regex pattern and lastTravStateIs is false" in {
     val analyzer = new DefaultAnalyzer(
@@ -273,6 +293,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when lastTravStateIs is false and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -284,6 +305,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract both email address and customer message" in {
     val analyzer = new DefaultAnalyzer(
@@ -296,6 +318,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
 
   operatorReinfConjunction should
@@ -309,6 +332,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when matching regex pattern and lastTravStateIs is true" in {
     val analyzer = new DefaultAnalyzer(
@@ -320,6 +344,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract email address when lastTravStateIs is true and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -331,6 +356,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and not update email address when matching regex pattern and lastTravStateIs is false" in {
     val analyzer = new DefaultAnalyzer(
@@ -342,6 +368,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "not trigger and not update email address when lastTravStateIs is false and matching regex pattern" in {
     val analyzer = new DefaultAnalyzer(
@@ -353,6 +380,7 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
   it should "trigger and extract both email address and customer message" in {
     val analyzer = new DefaultAnalyzer(
@@ -365,5 +393,124 @@ class OperatorOrderTest extends FlatSpec with Matchers {
     analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
     analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
     analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+
+  operatorMax should
+    "trigger and return variables passed as data" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomLastTravStateTrue)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger and update email variable" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger and update email variable in presence of multiple operands with lower score" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomExtractEmail, atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger and update email variable in presence of multiple operands with lower score (reverse order)" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomLastTravStateFalse, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger and update email variable in presence of multiple operands with score 1" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomExtractEmail, atomLastTravStateTrue)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger and update email variable in presence of multiple operands with score 1 (reverse order)" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomLastTravStateTrue, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "not trigger and not update email variable" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomLastTravStateFalse)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreFailure
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailExtracted
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger, update email variable and extract customer message" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(operatorMax, List(atomExtractQuery, atomExtractEmail)),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccess
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables(extractedQueryKey) shouldBe queryWithEmail
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
+  }
+  it should "trigger and add to result only the variable from operand with higher score" in {
+    val analyzer = new DefaultAnalyzer(
+      analyzerString(
+        operatorMax,
+        List(
+          atomExtractQuery,
+          analyzerString(operatorReinfConjunction, List(atomExtractEmail))
+        )
+      ),
+      restrictedArgs
+    )
+    val analyzerValue = analyzer.evaluate(queryWithEmail, data)
+    analyzerValue.score shouldBe scoreSuccessReinf1
+    analyzerValue.data.extractedVariables(extractedVarKey) shouldBe extractedVarValue
+    analyzerValue.data.extractedVariables(extractedEmailKey) shouldBe emailInQuery
+    analyzerValue.data.extractedVariables.contains(extractedQueryKey) shouldBe false
+    analyzerValue.data.traversedStates shouldBe Vector[String](travStateId)
+    analyzerValue.data.data shouldBe Map()
   }
 }

--- a/src/test/scala/com/getjenny/analyzer/atoms/AtomsTest.scala
+++ b/src/test/scala/com/getjenny/analyzer/atoms/AtomsTest.scala
@@ -5,6 +5,7 @@ package com.getjenny.analyzer.atoms
   */
 
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 
 class AtomsTest extends FlatSpec with Matchers {
 


### PR DESCRIPTION
Variables extracted evaluating ReinfConjunction operands, if already present in AnalyzersInternalData, override existing values. If final score of ReinfConjunction operator is zero, variables are not updated.